### PR TITLE
Don't call file.length() for every append if we can avoid it

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -18,6 +18,7 @@ import static ch.qos.logback.core.CoreConstants.MORE_INFO_PREFIX;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.Map;
@@ -237,6 +238,20 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
     public void setBufferSize(FileSize bufferSize) {
         addInfo("Setting bufferSize to [" + bufferSize.toString() + "]");
         this.bufferSize = bufferSize;
+    }
+
+    /**
+     * Returns the current position in the current file, as counted by
+     * {@link ch.qos.logback.core.recovery.ByteCountingOutputStream}, or zero if no file has been opened.
+     */
+    protected long getCurrentFilePosition() {
+        OutputStream outputStream = getOutputStream();
+        if (outputStream == null) {
+            return 0;
+        } else {
+            // we already cast to a ResilientFileOutputStream in #safeWrite()
+            return ((ResilientFileOutputStream) outputStream).getCount();
+        }
     }
 
     @Override

--- a/logback-core/src/main/java/ch/qos/logback/core/recovery/ByteCountingOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/recovery/ByteCountingOutputStream.java
@@ -1,0 +1,35 @@
+package ch.qos.logback.core.recovery;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ByteCountingOutputStream extends FilterOutputStream {
+
+    private long count;
+
+    public ByteCountingOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    public long getByteCount() {
+        return count;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+        count += len;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+        count++;
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/DefaultTimeBasedFileNamingAndTriggeringPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/DefaultTimeBasedFileNamingAndTriggeringPolicy.java
@@ -43,6 +43,10 @@ public class DefaultTimeBasedFileNamingAndTriggeringPolicy<E> extends TimeBasedF
         started = true;
     }
 
+    public boolean isTriggeringEvent(final File activeFile, final E event, long currentFilePosition) {
+        return isTriggeringEvent(activeFile, event);
+    }
+
     public boolean isTriggeringEvent(File activeFile, final E event) {
         long currentTime = getCurrentTime();
         long localNextCheck = atomicNextCheck.get();

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -242,7 +242,7 @@ public class RollingFileAppender<E> extends FileAppender<E> {
 
         triggeringPolicyLock.lock();
         try {
-            if (triggeringPolicy.isTriggeringEvent(currentlyActiveFile, event)) {
+            if (triggeringPolicy.isTriggeringEvent(currentlyActiveFile, event, getCurrentFilePosition())) {
                 rollover();
             }
         } finally {

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -141,7 +141,11 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
 
     @Override
     public boolean isTriggeringEvent(File activeFile, final E event) {
+        return isTriggeringEvent(activeFile, event, -1);
+    }
 
+    @Override
+    public boolean isTriggeringEvent(final File activeFile, final E event, long currentFilePosition) {
         long currentTime = getCurrentTime();
         long localNextCheck = atomicNextCheck.get();
 
@@ -158,10 +162,10 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
             return true;
         }
 
-        return checkSizeBasedTrigger(activeFile, currentTime);
+        return checkSizeBasedTrigger(activeFile, currentTime, currentFilePosition);
     }
 
-    private boolean checkSizeBasedTrigger(File activeFile, long currentTime) {
+    private boolean checkSizeBasedTrigger(File activeFile, long currentTime, long currentFilePosition) {
         // next check for roll-over based on size
         if (invocationGate.isTooSoon(currentTime)) {
             return false;
@@ -175,7 +179,8 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
             addWarn("maxFileSize = null");
             return false;
         }
-        if (activeFile.length() >= maxFileSize.getSize()) {
+        long activeFileLength = currentFilePosition >= 0 ? currentFilePosition : activeFile.length();
+        if (activeFileLength >= maxFileSize.getSize()) {
 
             elapsedPeriodsFileName = tbrp.fileNamePatternWithoutCompSuffix.convertMultipleArguments(dateInCurrentPeriod,
                     currentPeriodsCounter);

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicy.java
@@ -54,12 +54,17 @@ public class SizeBasedTriggeringPolicy<E> extends TriggeringPolicyBase<E> {
     }
 
 
-    public boolean isTriggeringEvent(final File activeFile, final E event) {
+    @Override
+    public boolean isTriggeringEvent(File activeFile, E event, long currentFilePosition) {
         long now = System.currentTimeMillis();
         if (invocationGate.isTooSoon(now))
             return false;
+        long activeFileLength = currentFilePosition >= 0 ? currentFilePosition : activeFile.length();
+        return (activeFileLength >= maxFileSize.getSize());
+    }
 
-        return (activeFile.length() >= maxFileSize.getSize());
+    public boolean isTriggeringEvent(final File activeFile, final E event) {
+        return isTriggeringEvent(activeFile, event, -1);
     }
 
     public FileSize getMaxFileSize() {

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedRollingPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedRollingPolicy.java
@@ -227,6 +227,11 @@ public class TimeBasedRollingPolicy<E> extends RollingPolicyBase implements Trig
         }
     }
 
+    @Override
+    public boolean isTriggeringEvent(File activeFile, E event, long currentFilePosition) {
+        return timeBasedFileNamingAndTriggeringPolicy.isTriggeringEvent(activeFile, event, currentFilePosition);
+    }
+
     /**
      * Delegates to the underlying timeBasedFileNamingAndTriggeringPolicy.
      *

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TriggeringPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TriggeringPolicy.java
@@ -35,4 +35,6 @@ public interface TriggeringPolicy<E> extends LifeCycle {
      * @return true if a roll-over should occur.
      */
     boolean isTriggeringEvent(final File activeFile, final E event);
+
+    boolean isTriggeringEvent(final File activeFile, final E event, long currentFilePosition);
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/recovery/ResilientOutputStreamTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/recovery/ResilientOutputStreamTest.java
@@ -13,6 +13,7 @@
  */
 package ch.qos.logback.core.recovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -51,15 +52,28 @@ public class ResilientOutputStreamTest {
 
         spy.write("a".getBytes());
         spy.flush();
+        assertEquals(1, spy.getCount());
 
         spy.getChannel().close();
         spy.write("b".getBytes());
         spy.flush();
+        // we have 2 in our countingoutput stream
+        // but the 'b' write failed due to the channel closing
+        assertEquals(2, spy.getCount());
         Thread.sleep(RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN + 10);
         spy.write("c".getBytes());
         spy.flush();
+
+        // since we recovered the output stream, we recomputed
+        // our count from the length of the file. both b and c were lost.
+        assertEquals(1, spy.getCount());
         verify(spy).openNewOutputStream();
 
+        Thread.sleep(RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN + 10);
+        spy.write("d".getBytes());
+        spy.flush();
+        // the 'd' write succeeds, so we have 2 bytes written
+        assertEquals(2, spy.getCount());
     }
 
 }


### PR DESCRIPTION
## Description
This is the port of this PR https://github.com/HubSpot/logback/pull/6 on branch 1.4.x, in preparation for enabling logback 1.4 to be used at HubSpot