### PR TITLE
Move `MAX_HISTORY` counter increment into `cleanPeriod` in 1.3.x

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,21 +11,21 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
-import ch.qos.logback.core.CoreConstants;
-import ch.qos.logback.core.LogbackMetrics;
-import ch.qos.logback.core.pattern.Converter;
-import ch.qos.logback.core.pattern.LiteralConverter;
-import ch.qos.logback.core.spi.ContextAwareBase;
-import ch.qos.logback.core.util.FileSize;
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 import java.io.File;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.LogbackMetrics;
+import ch.qos.logback.core.pattern.Converter;
+import ch.qos.logback.core.pattern.LiteralConverter;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.util.FileSize;
 
 public class TimeBasedArchiveRemover extends ContextAwareBase implements ArchiveRemover {
 

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,21 +11,21 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
-
-import java.io.File;
-import java.time.Instant;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LogbackMetrics;
 import ch.qos.logback.core.pattern.Converter;
 import ch.qos.logback.core.pattern.LiteralConverter;
 import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.util.FileSize;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 public class TimeBasedArchiveRemover extends ContextAwareBase implements ArchiveRemover {
 
@@ -99,6 +99,8 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
         File[] matchingFileArray = getFilesInPeriod(instantOfPeriodToClean);
 
         for (File f : matchingFileArray) {
+            LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
+            LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
             checkAndDeleteFile(f);
         }
 
@@ -117,10 +119,6 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
             addWarn("Cannot delete non existent file");
             return false;
         }
-
-        LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
-        LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
-
         boolean result = f.delete();
         if (!result) {
             addWarn("Failed to delete file " + f.toString());


### PR DESCRIPTION
### Why

The deleted-log-file metrics were added to 1.3.x in https://github.com/HubSpot/logback/pull/1

The `maxHistory` metric is currently incremented in [`checkAndDeleteFile()`](https://github.com/HubSpot/logback/blob/ab136b896fd0165ddc034fa7f1d1d06d4ba742ee/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java#L111), which is _also_ invoked by [`capTotalSize()`](https://github.com/HubSpot/logback/blob/ab136b896fd0165ddc034fa7f1d1d06d4ba742ee/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java#L150) (a change from 1.2.x to 1.3.x).

This means that hitting the total size cap will increment both `totalSizeCap` and `maxHistory` counters.

### What

This PR moves the `maxHistory` update out of `checkAndDeleteFile()` and into `cleanPeriod()`, where max history is checked.

I'll also add this to 1.4.x in another PR.

cc @jaredstehler 