### PR TITLE
Move `MAX_HISTORY` counter increment into `cleanPeriod` in 1.4.x

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,21 +11,21 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
-import ch.qos.logback.core.CoreConstants;
-import ch.qos.logback.core.LogbackMetrics;
-import ch.qos.logback.core.pattern.Converter;
-import ch.qos.logback.core.pattern.LiteralConverter;
-import ch.qos.logback.core.spi.ContextAwareBase;
-import ch.qos.logback.core.util.FileSize;
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 import java.io.File;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.LogbackMetrics;
+import ch.qos.logback.core.pattern.Converter;
+import ch.qos.logback.core.pattern.LiteralConverter;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.util.FileSize;
 
 public class TimeBasedArchiveRemover extends ContextAwareBase implements ArchiveRemover {
 

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,21 +11,21 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
-
-import java.io.File;
-import java.time.Instant;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LogbackMetrics;
 import ch.qos.logback.core.pattern.Converter;
 import ch.qos.logback.core.pattern.LiteralConverter;
 import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.util.FileSize;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 public class TimeBasedArchiveRemover extends ContextAwareBase implements ArchiveRemover {
 
@@ -99,6 +99,8 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
         File[] matchingFileArray = getFilesInPeriod(instantOfPeriodToClean);
 
         for (File f : matchingFileArray) {
+            LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
+            LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
             checkAndDeleteFile(f);
         }
 
@@ -117,10 +119,6 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
             addWarn("Cannot delete non existent file");
             return false;
         }
-
-        LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
-        LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
-       
         boolean result = f.delete();
         if (!result) {
             addWarn("Failed to delete file " + f.toString());


### PR DESCRIPTION
Porting the same changes from https://github.com/HubSpot/logback/pull/11 to 1.4.x, as done in https://github.com/HubSpot/logback/pull/7

cc @jaredstehler 