### PR TITLE
Only report delete metrics if `checkAndDeleteFile` succeeds

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,14 +11,14 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
+
 import java.io.File;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LogbackMetrics;

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -99,9 +99,10 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
         File[] matchingFileArray = getFilesInPeriod(instantOfPeriodToClean);
 
         for (File f : matchingFileArray) {
-            LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
-            LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
-            checkAndDeleteFile(f);
+            if (checkAndDeleteFile(f)) {
+                LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
+                LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
+            }
         }
 
         if (parentClean && matchingFileArray.length > 0) {
@@ -140,12 +141,10 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
                     // assume that deletion attempt will succeed.
                     totalRemoved += size;
 
-                    LogbackMetrics.getDeletedLogFilesCounter(TOTAL_SIZE_CAP,
-                            fileNamePattern).inc();
-                    LogbackMetrics.getDeletedLogFileSizeHistogram(TOTAL_SIZE_CAP,
-                            fileNamePattern).update(f.length());
-
-                    checkAndDeleteFile(f);
+                    if (checkAndDeleteFile(f)) {
+                        LogbackMetrics.getDeletedLogFilesCounter(TOTAL_SIZE_CAP, fileNamePattern).inc();
+                        LogbackMetrics.getDeletedLogFileSizeHistogram(TOTAL_SIZE_CAP, fileNamePattern).update(f.length());
+                    }
                 }
                 totalSize += size;
             }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -11,14 +11,14 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
-import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
-import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
-
 import java.io.File;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+
+import static ch.qos.logback.core.CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.MAX_HISTORY;
+import static ch.qos.logback.core.rolling.helper.ArchiveRemoverReason.TOTAL_SIZE_CAP;
 
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LogbackMetrics;
@@ -99,9 +99,10 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
         File[] matchingFileArray = getFilesInPeriod(instantOfPeriodToClean);
 
         for (File f : matchingFileArray) {
+            long size = f.length();
             if (checkAndDeleteFile(f)) {
                 LogbackMetrics.getDeletedLogFilesCounter(MAX_HISTORY, fileNamePattern).inc();
-                LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(f.length());
+                LogbackMetrics.getDeletedLogFileSizeHistogram(MAX_HISTORY, fileNamePattern).update(size);
             }
         }
 
@@ -143,7 +144,7 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
 
                     if (checkAndDeleteFile(f)) {
                         LogbackMetrics.getDeletedLogFilesCounter(TOTAL_SIZE_CAP, fileNamePattern).inc();
-                        LogbackMetrics.getDeletedLogFileSizeHistogram(TOTAL_SIZE_CAP, fileNamePattern).update(f.length());
+                        LogbackMetrics.getDeletedLogFileSizeHistogram(TOTAL_SIZE_CAP, fileNamePattern).update(size);
                     }
                 }
                 totalSize += size;


### PR DESCRIPTION
The logback delete metrics will report values regardless of whether the delete succeeds. We can use the result of [`checkAndDeleteFile`](https://github.com/qos-ch/logback/blob/branch_1.3.x/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java#L108-L123) to conditionally update the metric. This will also protect against null/non-existent files.

cc @jaredstehler 